### PR TITLE
Fix g bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # git-open
 
+## 0.3.1
+
+- Funny bug in TrimEnd(). If a repository name ends with "g", "i", or "t" then that letter gets trimmed with the cleaning up of ".git" from the remote URL. https://github.com/PowerShell/PowerShell/issues/6174
+
 ## 0.3.0
 
 -- Will now work when invoked from a folder inside of a repo by finding the git config uproot. 

--- a/src/Private/Get-UrlFromGitConfig.Tests.ps1
+++ b/src/Private/Get-UrlFromGitConfig.Tests.ps1
@@ -19,5 +19,10 @@ InModuleScope git-open {
     It 'Parses the URL from an Azure Devops config file' {
       Get-UrlFromGitConfig -ConfigPath $(Join-Path $repoRoot 'test/fixtures/gitconfig.azuredevops.txt') | Should be 'https://organization@dev.azure.com/organization/project/_git/repo'
     }
+
+    It 'Does not strip off the trailing g in a repo name' {
+      Get-UrlFromGitConfig -ConfigPath $(Join-Path $repoRoot 'test/fixtures/gitconfig.trimend_bug.txt') | Should be 'https://github.com/nhudacin/hellog'
+    }
+
   }
 }

--- a/src/Private/Get-UrlFromGitConfig.ps1
+++ b/src/Private/Get-UrlFromGitConfig.ps1
@@ -20,7 +20,7 @@ function Get-UrlFromGitConfig {
     $sanitizedUrl = $sanitizedUrl.Trim()
 
     if ($sanitizedUrl.EndsWith('.git')) {
-      $sanitizedUrl = $sanitizedUrl.TrimEnd('.git')
+      $sanitizedUrl = $sanitizedUrl.Replace('.git','')
     }
   }
 

--- a/src/git-open.psd1
+++ b/src/git-open.psd1
@@ -4,7 +4,7 @@
     RootModule = 'git-open.psm1'
     
     # Version number of this module.
-    ModuleVersion = '0.3.0'
+    ModuleVersion = '0.3.1'
     
     # ID used to uniquely identify this module
     GUID = 'd90bd9b8-8e30-4931-8297-da0cb1a3fffc'

--- a/test/fixtures/gitconfig.trimend_bug.txt
+++ b/test/fixtures/gitconfig.trimend_bug.txt
@@ -1,0 +1,13 @@
+[core]
+  repositoryformatversion = 0
+  filemode = false
+  bare = false
+  logallrefupdates = true
+  ignorecase = true
+[remote "origin"]
+  # THIS IS THE DIFFERENCE! Fixing bug with trimEnd where it strips the g off the reponame
+  url = https://github.com/nhudacin/hellog.git
+  fetch = +refs/heads/*:refs/remotes/origin/*
+[branch "master"]
+  remote = origin
+  merge = refs/heads/master


### PR DESCRIPTION
## 0.3.1

- Funny bug in TrimEnd(). If a repository name ends with "g", "i", or "t" then that letter gets trimmed with the cleaning up of ".git" from the remote URL. https://github.com/PowerShell/PowerShell/issues/6174